### PR TITLE
Fix International Name Support

### DIFF
--- a/ruddock/modules/account/helpers.py
+++ b/ruddock/modules/account/helpers.py
@@ -99,8 +99,8 @@ def handle_request_account(uid, last_name):
     WHERE uid = :uid
     """)
   result = flask.g.db.execute(query, uid=uid).first()
-  name_match = result["last_name"].decode('utf-8').lower() == last_name.lower()
-  if result is None or not name_match:
+  if (result is None or
+      result["last_name"].decode('utf-8').lower() != last_name.lower()):
     return (False, "Incorrect UID and/or name.")
   if result["username"] is not None:
     return (False, "You already have an account. Try recovering it?")

--- a/ruddock/modules/account/helpers.py
+++ b/ruddock/modules/account/helpers.py
@@ -99,7 +99,8 @@ def handle_request_account(uid, last_name):
     WHERE uid = :uid
     """)
   result = flask.g.db.execute(query, uid=uid).first()
-  if result is None or result["last_name"].lower() != last_name.lower():
+  name_match = result["last_name"].decode('utf-8').lower() == last_name.lower()
+  if result is None or not name_match:
     return (False, "Incorrect UID and/or name.")
   if result["username"] is not None:
     return (False, "You already have an account. Try recovering it?")

--- a/ruddock/modules/account/templates/create_account.html
+++ b/ruddock/modules/account/templates/create_account.html
@@ -24,11 +24,11 @@
   <table class="form">
     <tr>
       <td>First Name</td>
-      <td>{{ user_data['first_name'] }}</td>
+      <td>{{ user_data['first_name'].decode('utf-8') }}</td>
     </tr>
     <tr>
       <td>Last Name</td>
-      <td>{{ user_data['last_name'] }}</td>
+      <td>{{ user_data['last_name'].decode('utf-8') }}</td>
     </tr>
     <tr>
       <td>Matriculation Year</td>
@@ -40,7 +40,7 @@
     </tr>
     <tr>
       <td>Email</td>
-      <td>{{ user_data['email'] }}</td>
+      <td>{{ user_data['email'].decode('utf-8') }}</td>
     </tr>
     <tr>
       <td>Birthday</td>

--- a/ruddock/modules/admin/member_helpers.py
+++ b/ruddock/modules/admin/member_helpers.py
@@ -36,8 +36,8 @@ class NewMember:
     is_valid = True
     if not validation_utils.validate_name(self.first_name, flash_errors):
       is_valid = False
-    if not validation_utils.validate_name(self.last_name, flash_errors):
-      is_valid = False
+    # validate_name just checks for empty string. Last name is allowed to be
+    # empty since people are given only one name in some cultures.
     if not validation_utils.validate_year(self.matriculation_year, flash_errors):
       is_valid = False
     if not validation_utils.validate_year(self.graduation_year, flash_errors):

--- a/ruddock/modules/admin/member_helpers.py
+++ b/ruddock/modules/admin/member_helpers.py
@@ -10,14 +10,14 @@ class NewMember:
   """Class containing data for adding a single new member."""
   def __init__(self, first_name, last_name, matriculation_year, graduation_year,
       uid, email, membership_desc):
-    self.first_name = first_name
-    self.last_name = last_name
-    self.name = first_name + ' ' + last_name
-    self.matriculation_year = matriculation_year
-    self.graduation_year = graduation_year
-    self.uid = uid
-    self.email = email
-    self.membership_desc = membership_desc
+    self.first_name = first_name.encode('utf-8')
+    self.last_name = last_name.encode('utf-8')
+    self.name = (first_name + ' ' + last_name).encode('utf-8')
+    self.matriculation_year = matriculation_year.encode('utf-8')
+    self.graduation_year = graduation_year.encode('utf-8')
+    self.uid = uid.encode('utf-8')
+    self.email = email.encode('utf-8')
+    self.membership_desc = membership_desc.encode('utf-8')
     # Membership type is set from the membership desc.
     self.member_type = None
     self.set_member_type()

--- a/ruddock/modules/admin/member_helpers.py
+++ b/ruddock/modules/admin/member_helpers.py
@@ -13,19 +13,24 @@ class NewMember:
     self.first_name = first_name.encode('utf-8')
     self.last_name = last_name.encode('utf-8')
     self.name = (first_name + ' ' + last_name).encode('utf-8')
-    self.matriculation_year = matriculation_year.encode('utf-8')
-    self.graduation_year = graduation_year.encode('utf-8')
-    self.uid = uid.encode('utf-8')
-    self.email = email.encode('utf-8')
-    self.membership_desc = membership_desc.encode('utf-8')
+    self.matriculation_year = matriculation_year
+    self.graduation_year = graduation_year
+    self.uid = uid
+    self.email = email
+    self.membership_desc = membership_desc
     # Membership type is set from the membership desc.
     self.member_type = None
     self.set_member_type()
 
   def __str__(self):
     """Converts to a CSV string."""
-    return ','.join([self.first_name, self.last_name, self.matriculation_year, \
-        self.graduation_year, self.uid, self.email, self.membership_desc])
+    return u','.join([self.first_name.decode('utf-8'),
+                     self.last_name.decode('utf-8'),
+                     self.matriculation_year,
+                     self.graduation_year,
+                     self.uid,
+                     self.email,
+                     self.membership_desc]).encode('utf-8')
 
   def validate_data(self, flash_errors=True):
     """

--- a/ruddock/modules/admin/templates/add_members_confirm.html
+++ b/ruddock/modules/admin/templates/add_members_confirm.html
@@ -19,19 +19,19 @@ Are you sure you want to add the following members?
     <tbody>
       {% for new_member in new_member_list.new_member_list %}
       <tr>
-        <td>{{ new_member.first_name }}</td>
-        <td>{{ new_member.last_name }}</td>
+        <td>{{ new_member.first_name.decode('utf-8') }}</td>
+        <td>{{ new_member.last_name.decode('utf-8') }}</td>
         <td>{{ new_member.matriculation_year }}</td>
         <td>{{ new_member.graduation_year }}</td>
         <td>{{ new_member.uid }}</td>
-        <td>{{ new_member.email }}</td>
+        <td>{{ new_member.email.decode('utf-8') }}</td>
         <td>{{ new_member.membership_desc }}</td>
       {% endfor %}
     </tbody>
   </table>
   <br>
   {# Pass along the actual data as a string. #}
-  <input type="hidden" name="new_member_data" value="{{ data_string }}" />
+  <input type="hidden" name="new_member_data" value="{{ data_string.decode('utf-8') }}" />
   <button type="button"
     onclick="location.href='{{ url_for('admin.add_members') }}'">No</button>
   <button type="submit">Yes</button>

--- a/ruddock/modules/admin/templates/create_account_reminder.html
+++ b/ruddock/modules/admin/templates/create_account_reminder.html
@@ -13,9 +13,9 @@ Do you want to send a reminder email to these people?<br><br>
     </tr></thead>
     {% for member in data %}
     <tr>
-      <td>{{ member['fname'] }}</td>
-      <td>{{ member['lname'] }}</td>
-      <td>{{ member['email'] }}</td>
+      <td>{{ member['fname'].decode('utf-8') }}</td>
+      <td>{{ member['lname'].decode('utf-8') }}</td>
+      <td>{{ member['email'].decode('utf-8') }}</td>
     </tr>
     {% endfor %}
   </table><br>

--- a/ruddock/modules/admin/templates/delete_assignment.html
+++ b/ruddock/modules/admin/templates/delete_assignment.html
@@ -12,7 +12,7 @@ Confirm deleting this assignment?
     </tr>
     <tr>
       <td>Name:</td>
-      <td>{{ assignment['name'] }}</td>
+      <td>{{ assignment['name'].decode('utf-8') }}</td>
     </tr>
     <tr>
       <td>Start date:</td>

--- a/ruddock/modules/admin/templates/edit_assignment.html
+++ b/ruddock/modules/admin/templates/edit_assignment.html
@@ -22,7 +22,7 @@ Edit an existing assignment. Start/end dates should default to Feb 1 for elected
     </tr>
     <tr>
       <td>Name:</td>
-      <td>{{ assignment['name'] }}</td>
+      <td>{{ assignment['name'].decode('utf-8') }}</td>
     </tr>
     <tr>
       <td>Start date:</td>

--- a/ruddock/modules/admin/templates/positionslib.html
+++ b/ruddock/modules/admin/templates/positionslib.html
@@ -18,7 +18,7 @@
       {% for assignment in assignments %}
         <tr>
           <td>{{ assignment['office_name'] }}</td>
-          <td>{{ assignment['name'] }}</td>
+          <td>{{ assignment['name'].decode('utf-8') }}</td>
           <td>{{ assignment['start_date'] }}</td>
           <td>{{ assignment['end_date'] }}</td>
           <td>

--- a/ruddock/modules/birthdays/templates/bday_list.html
+++ b/ruddock/modules/birthdays/templates/bday_list.html
@@ -17,7 +17,7 @@
     {% for r in bdays %}
     <tr>
       <td>{{ r["date"] }}</td>
-      <td>{{ r["name"] }}</td>
+      <td>{{ r["name"].decode('utf-8') }}</td>
       <td>{{ r["age"] }}</td>
       <td>{{ r["byear"] }}</td>
     </tr>
@@ -39,7 +39,7 @@ Contact these people and get them to add their birthdays!
 
   <tbody>
     {% for x in unknowns %}
-    <tr><td>{{ x }}</td></tr>
+    <tr><td>{{ x.decode('utf-8') }}</td></tr>
     {% endfor %}
   </tbody>
 

--- a/ruddock/modules/government/templates/government.html
+++ b/ruddock/modules/government/templates/government.html
@@ -4,7 +4,7 @@
   {% for name, email, positions in assignment_data %}
     {# Display name and email of group #}
     <h2>{{ name }}</h2>
-    <h3>{{ "[" + email + " at ruddock.caltech.edu" + "]" if email }}</h3>
+    <h3>{{ "[" + email.decode('utf-8') + " at ruddock.caltech.edu" + "]" if email }}</h3>
     <br>
     <table class="userlist" id="sort-{{ name }}">
     {# First display header #}
@@ -22,7 +22,7 @@
         <tr>
         {% endif %}
           <td>{{ position['office_name'] }}</td>
-          <td>{{ position['name'] }}</td>
+          <td>{{ position['name'].decode('utf-8') }}</td>
           <td>{{ position['office_email'] if position['office_email'] else '[None]' }}</td>
         </tr>
       {% endfor %}

--- a/ruddock/modules/hassle/templates/hassle.html
+++ b/ruddock/modules/hassle/templates/hassle.html
@@ -99,7 +99,7 @@ $(document).ready(function() {
             <select id="name_select" name="user_id">
               {% for participant in available_participants %}
               <option value="{{ participant['user_id'] }}">
-              {{ participant['name'] }}
+              {{ participant['name'].decode('utf-8') }}
               </option>
               {% endfor %}
             </select>
@@ -112,7 +112,7 @@ $(document).ready(function() {
               <option value="none">-- No roommate --</option>
               {% for participant in available_participants %}
               <option value="{{ participant['user_id'] }}">
-              {{ participant['name'] }}
+              {{ participant['name'].decode('utf-8') }}
               </option>
               {% endfor %}
             </select>
@@ -125,7 +125,7 @@ $(document).ready(function() {
               <option value="none">-- Not a triple --</option>
               {% for participant in available_participants %}
               <option value="{{ participant['user_id'] }}">
-              {{ participant['name'] }}
+              {{ participant['name'].decode('utf-8') }}
               </option>
               {% endfor %}
             </select>

--- a/ruddock/modules/hassle/templates/hassle_new_confirm.html
+++ b/ruddock/modules/hassle/templates/hassle_new_confirm.html
@@ -22,7 +22,7 @@ Please verify that the participating members and rooms is correct.<br><br>
       <tbody>
         {% for member in participants %}
         <tr>
-          <td>{{ member['name'] }}</td>
+          <td>{{ member['name'].decode('utf-8') }}</td>
           <td>{{ member['graduation_year'] }}</td>
           <td>{{ member['membership_desc'] }}</td>
         </tr>

--- a/ruddock/modules/hassle/templates/hassle_new_participants.html
+++ b/ruddock/modules/hassle/templates/hassle_new_participants.html
@@ -72,7 +72,7 @@ Select everyone who will be participating in this room hassle.<br><br>
             value="{{ member['user_id'] }}"
             {{ 'checked' if member['participating'] }} />
         </td>
-        <td>{{ member['name'] }}</td>
+        <td>{{ member['name'].decode('utf-8') }}</td>
         <td>{{ member['graduation_year'] }}</td>
         <td>{{ member['membership_desc'] }}</td>
       </tr>

--- a/ruddock/modules/rotation/templates/directory.html
+++ b/ruddock/modules/rotation/templates/directory.html
@@ -26,7 +26,7 @@
       <img src="{{ url_for('rotation.serve_image', prefrosh_id=prefrosh['prefrosh_id']) }}"
       height = "200">
     </td>
-    <td>{{ prefrosh['full_name'] }}</td>
+    <td>{{ prefrosh['full_name'].decode('utf-8') }}</td>
     <td>{{ prefrosh['bucket_name'] }}</td>
     <td>{{ prefrosh['votes_neg_two'] }}</td>
     <td>{{ prefrosh['votes_neg_one'] }}</td>

--- a/ruddock/modules/rotation/templates/move.html
+++ b/ruddock/modules/rotation/templates/move.html
@@ -22,7 +22,7 @@ function updateComment(name, comment) {
           <img src="{{ url_for('rotation.serve_image', prefrosh_id=prefrosh['prefrosh_id']) }}"
         height = "300">
           <a class="prefroshName" href="{{ url_for('rotation.show_prefrosh',
-        prefrosh_id=prefrosh['prefrosh_id']) }}">{{ prefrosh['full_name'] }}</a>
+        prefrosh_id=prefrosh['prefrosh_id']) }}">{{ prefrosh['full_name'].decode('utf-8') }}</a>
           <div class="container">
             <table>
               <thead>
@@ -40,7 +40,7 @@ function updateComment(name, comment) {
                 </tr>
               </tbody>
             </table>
-            <button onclick="updateComment('{{ prefrosh['first_name'] }}',
+            <button onclick="updateComment('{{ prefrosh['first_name'].decode('utf-8') }}',
                               '{{ prefrosh['escaped_comments'] }}')">Comments</button>
             <form action="{{ url_for('rotation.change_bucket', prefrosh_id=prefrosh['prefrosh_id']) }}"
               method="post" id="change_bucket_form">
@@ -67,7 +67,7 @@ function updateComment(name, comment) {
           <img src="{{ url_for('rotation.serve_image', prefrosh_id=prefrosh['prefrosh_id']) }}"
         height = "300">
           <a class="prefroshName" href="{{ url_for('rotation.show_prefrosh',
-        prefrosh_id=prefrosh['prefrosh_id']) }}">{{ prefrosh['full_name'] }}</a>
+        prefrosh_id=prefrosh['prefrosh_id']) }}">{{ prefrosh['full_name'].decode('utf-8') }}</a>
           <div class="container">
             <table>
               <thead>

--- a/ruddock/modules/rotation/templates/prefrosh.html
+++ b/ruddock/modules/rotation/templates/prefrosh.html
@@ -27,7 +27,7 @@
   <a href ="{{ url_for('rotation.show_prefrosh', prefrosh_id=next_id) }}">Next</a>
 {% endif %}
 
-<h1>{{ full_name }}</h1>
+<h1>{{ full_name.decode('utf-8') }}</h1>
 <div class="container">
   <div>
     <img src="{{ url_for('rotation.serve_image', prefrosh_id=prefrosh['prefrosh_id']) }}"

--- a/ruddock/modules/users/templates/memberlist.html
+++ b/ruddock/modules/users/templates/memberlist.html
@@ -41,9 +41,9 @@ Click on the columns to sort.
     <tr>
     {% endif %}
     {# Display data #}
-    <td>{{ member['first_name'] }}</td>
-    <td>{{ member['last_name'] }}</td>
-    <td>{{ member['email'] }}</td>
+    <td>{{ member['first_name'].decode('utf-8') }}</td>
+    <td>{{ member['last_name'].decode('utf-8') }}</td>
+    <td>{{ member['email'].decode('utf-8') }}</td>
     {# Matriculation and graduation year might not be set. #}
     <td>{{ member['matriculation_year'] if member['matriculation_year'] is not none else '' }}</td>
     <td>{{ member['graduation_year'] if member['graduation_year'] is not none else '' }}</td>

--- a/ruddock/modules/users/templates/view_user.html
+++ b/ruddock/modules/users/templates/view_user.html
@@ -3,7 +3,7 @@
 {% block body %}
 <center>
   {# Name and subtitle #}
-  <h2>{{ info["name"] }}</h2>
+  <h2>{{ info["name"].decode('utf-8') }}</h2>
   <h3>
     {% if info["major"] is not none and info["major"]|length > 0 %}
       {{ info["major"] }}
@@ -21,8 +21,8 @@
 
   {# Contact Information #}
   <div id="view_user_contact">
-    <a href="&#109;&#097;&#105;&#108;&#116;&#111;:{{ info["email"] }}">
-      {{ info["email"] }}
+    <a href="&#109;&#097;&#105;&#108;&#116;&#111;:{{ info["email"].decode('utf-8') }}">
+      {{ info["email"].decode('utf-8') }}
     </a>
     {% if info["msc"] is not none %}
     &#8226; MSC {{ info["msc"] }}

--- a/ruddock/validation_utils.py
+++ b/ruddock/validation_utils.py
@@ -7,7 +7,6 @@ import decimal
 from ruddock import constants
 
 username_regex = re.compile(r'^[a-z][a-z0-9_-]*$', re.I)
-name_regex = re.compile(r"^[a-z][a-z '-]{0,30}[a-z]$", re.I)
 uid_regex = re.compile(r'^[0-9]{7,8}$')
 year_regex = re.compile(r'^[0-9]{4}$')
 email_regex = re.compile(r'^[a-z0-9\.\_\%\+\-]+@[a-z0-9\.\-]+\.[a-z]+$', re.I)
@@ -73,11 +72,13 @@ def validate_password(password, password2, flash_errors=True):
 
 def validate_name(name, flash_errors=True):
   """Validates a name. Flashes errors if flash_errors is True."""
-  # Allow letters, spaces, hyphens, and apostrophes.
-  # First and last characters must be letters.
-  if not name_regex.match(name):
+  # Allow anything besides empty string. Input will be sanitized by
+  # SQLAlchemy.execute() when entered into the database, so as long as
+  # we use that everywhere, we're okay.
+  # http://www.kalzumeus.com/2010/06/17/falsehoods-programmers-believe-about-names/
+  if name == '':
     if flash_errors:
-      flask.flash("'{0}' is not a valid name.".format(name))
+      flask.flash(u"'{0}' is not a valid name.".format(name))
     return False
   return True
 
@@ -85,7 +86,7 @@ def validate_uid(uid, flash_errors=True):
   """Validates a UID. Flashes errors if flash_errors is True."""
   if not uid_regex.match(uid):
     if flash_errors:
-      flask.flash("'{0}' is not a valid UID.".format(uid))
+      flask.flash(u"'{0}' is not a valid UID.".format(uid))
     return False
   return True
 
@@ -106,14 +107,14 @@ def validate_year(year, flash_errors=True):
       and int(year) <= 2155:
     return True
   if flash_errors:
-    flask.flash("'{0}' is not a valid year.".format(year))
+    flask.flash(u"'{0}' is not a valid year.".format(year))
   return False
 
 def validate_email(email, flash_errors=True):
   """Validates an email. Flashes errrors if flash_errors is True."""
   if not email_regex.match(email):
     if flash_errors:
-      flask.flash("'{0}' is not a valid email.".format(email))
+      flask.flash(u"'{0}' is not a valid email.".format(email))
     return False
   return True
 

--- a/ruddock/validation_utils.py
+++ b/ruddock/validation_utils.py
@@ -78,7 +78,7 @@ def validate_name(name, flash_errors=True):
   # http://www.kalzumeus.com/2010/06/17/falsehoods-programmers-believe-about-names/
   if name == '':
     if flash_errors:
-      flask.flash(u"'{0}' is not a valid name.".format(name))
+      flask.flash("Name cannot be empty.")
     return False
   return True
 


### PR DESCRIPTION
Adding members with non-ASCII characters in their names should now be properly supported. This was just a matter of encoding names when we get them and decoding them when we need to output them. This involved a lot of minor changes, but I guess it was better than carelessly setting a new default encoding, as outlined [here](https://anonbadger.wordpress.com/2015/06/16/why-sys-setdefaultencoding-will-break-code/).

Also, name validation is less strict now; we basically just require the first name to be non-empty, inspired by [this blog post](https://www.kalzumeus.com/2010/06/17/falsehoods-programmers-believe-about-names/).

This hasn't been extensively tested yet besides basic functionality, so I wouldn't be surprised if there's some errors. Let me know if you catch any!